### PR TITLE
Fix compilation warnings in offsetoff macro

### DIFF
--- a/list.h
+++ b/list.h
@@ -37,7 +37,7 @@
 /**
  * Get offset of a member
  */
-#define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
+#define offsetof(TYPE, MEMBER) ((size_t) ((unsigned long)&((TYPE *)0)->MEMBER))
 #endif
 
 /**


### PR DESCRIPTION
## Summary of Changes

Fix the compilation warning from `offsetof` macro

```
s_alloc/list.h:40:33: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
   40 | #define offsetof(TYPE, MEMBER) ((size_t) (((void *)&((TYPE *)0)->MEMBER)))

```

Signed-off-by: Sebastian Ene <sene@apache.org>