### PR TITLE
Bugfix: Space from an allocated node may overlap on a new node head

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 OUT = allocator
-LIBRARY_CFLAGS := $(CFLAGS) -Wall -Werror 
+LIBRARY_CFLAGS := $(CFLAGS) -Wall -Werror
 TOPDIR ?= .
 TMP_LIB ?= lib_salloc.a 
 LIBRARY := $(TOPDIR)/$(TMP_LIB)
-SRC := s_heap.c 
+SRC := s_heap.c list.c
 TEST_SRC := main.c
 OBJS := $(patsubst %.c,%.o,$(SRC))
 

--- a/list.c
+++ b/list.c
@@ -1,0 +1,65 @@
+#include "list.h"
+
+/**
+ * list_sort - sort a list
+ * @priv: private data, opaque to list_sort(), passed to @cmp
+ * @head: the list to sort
+ * @cmp: the elements comparison function
+ *
+ * This function implements "insertion sort", which has O(N^2)
+ * complexity.
+ *
+ * The comparison function @cmp must return a negative value if @a
+ * should sort before @b, and a positive value if @a should sort after
+ * @b. If @a and @b are equivalent, and their original relative
+ * ordering is to be preserved, @cmp must return 0.
+ */
+void list_sort(void *priv,
+               struct list_head *head,
+               comparator_cb cb)
+{
+
+  struct list_head *pos, *prev, *next_next;
+  int ret;
+  int is_order_wrong;
+
+  if (list_empty(head) || list_length(head) == 1)
+    return;
+
+  do
+  {
+    /* reset the flag to indicate that the list is in order */
+
+    is_order_wrong = 0;
+
+    list_for_each(pos, head)
+    {
+      struct list_head *next_node = pos->next;
+      if (next_node == head)
+        break;
+ 
+      ret = cb(priv, pos, next_node);
+      if (ret > 0)
+      {
+        /* The current node is greater than the next_node
+         * Let's move the current node at the end..
+         */
+
+        prev      = pos->prev; 
+        next_next = next_node->next;
+
+        prev->next      = next_node;
+        next_node->prev = prev; 
+
+        next_node->next = pos;
+        pos->prev       = next_node;
+
+        pos->next       = next_next;
+        next_next->prev = pos;
+
+        is_order_wrong = 1;
+        break;
+      }
+    }
+  } while (is_order_wrong);
+}

--- a/main.c
+++ b/main.c
@@ -7,6 +7,12 @@
 
 #include "s_heap.h"
 
+#define TEST_HEAP_LENGTH_BYTES    (128 * 1024 * 1024)  
+#define TEST_ARRAY_SIZE           (200)
+#define RANDOM_ALLOCATION_SIZE    (8 * 1024)
+#define RANDOM_REALLOCATION_SIZE  (8 * 1024)
+
+
 void s_dbg_heap(heap_t *my_heap)
 {
   printf("\n################ Heap details ####################\n");
@@ -19,9 +25,11 @@ void s_dbg_heap(heap_t *my_heap)
   mem_node_t *node = NULL;
   list_for_each_entry (node, &my_heap->g_used_heap_list, node_list)
   {
+
     printf("leaked block start = 0x%lx, size = %u blocks\n",
            (unsigned long)node->chunk_addr,
            node->mask.size);
+    assert(0);
   }
 
   printf("################ Free blocks ##################\n");
@@ -38,15 +46,13 @@ void s_dbg_heap(heap_t *my_heap)
 int main(void)
 {
   static heap_t my_heap;
-  const size_t sz = 1024 * 1024;
-  const uint32_t TEST_ARRAY_SIZE = 200;
 
-  void *start_addr = malloc(sz);
+  void *start_addr = malloc(TEST_HEAP_LENGTH_BYTES);
   assert(start_addr);
 
   s_init(&my_heap,
          start_addr,
-         start_addr + sz);
+         start_addr + TEST_HEAP_LENGTH_BYTES);
 
   uint32_t *ptrs[TEST_ARRAY_SIZE];
   uint32_t size[TEST_ARRAY_SIZE];
@@ -61,7 +67,7 @@ int main(void)
 
 		for (int i = 0; i < TEST_ARRAY_SIZE; i++)
 		{
-			size_t sz = rand() % 100;
+			size_t sz = rand() % RANDOM_ALLOCATION_SIZE;
 			size[i] = sz;
 			ptrs[i] = s_alloc(sz, &my_heap);
 			if (ptrs[i] == NULL)
@@ -86,7 +92,7 @@ int main(void)
 
 			if (sz % 2 == 0)
 			{
-				size_t new_size = rand() % 100;
+				size_t new_size = rand() % RANDOM_REALLOCATION_SIZE;
 				size[i] = new_size;
 				ptrs[i] = s_realloc(ptrs[i], new_size, &my_heap);
 				if (ptrs[i] == NULL)
@@ -162,7 +168,7 @@ int main(void)
 		printf("\r\nIteration : %u\n", ++it);
 		printf("\r\n##############\r\n");
 		printf("\r\n##############\r\n");
-    sleep(1);
+//    sleep(1);
 	}
   free(start_addr);
   return 0;


### PR DESCRIPTION

 
 ## Summary of changes

This PR fixes the following issues:
 - broken circular list after list_sort(..) is applied
 - revert to O(N^2) list_sort implementation and create a separate file for it
 - space from an allocated node may overlap on the next_node header
 - improve testing and use larger memory areas
 - in s_free add a check to verify that we reached the end of a list before
   accessing the next (element)

Signed-off-by: Sebastian Ene <sebastian.ene07@gmail.com>